### PR TITLE
Test the QR codes with Zak on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,35 +90,38 @@ Thank you very much.
 | expected message: `Spende 420` | expected sender address `Mary Jane`, expected amount 23.42 CHF | (without amount) |
 | [donation parameters](http://localhost:9933/qr?format=html&udname=&udaddr1=&udaddr2=&udpost=&udcity=&udcountry=&udaddrtype=) | [invoice parameters](http://localhost:9933/qr?format=html&udname=Mary+Jane&udaddr1=Artikel+19b&amount=23.42) | [invoice without amount parameters](http://localhost:9933/qr?format=html&udname=Mary+Jane&udaddr1=Artikel+19b) |
 
-| QR code                | scanned with           | paid via | Notes                               |
-|------------------------|------------------------|----------|-------------------------------------|
-| donation               | SIX QR-bill validation |          |                                     |
-| invoice                | SIX QR-bill validation |          |                                     |
-| invoice without amount | SIX QR-bill validation |          |                                     |
-| donation               | ZKB eBanking (iOS)     | ZKB      |                                     |
-| invoice                | ZKB eBanking (iOS)     |          |                                     |
-| invoice without amount | ZKB eBanking (iOS)     |          |                                     |
-| donation               | Revolut (iOS)          |          |                                     |
-| invoice                | Revolut (iOS)          |          | message replaced with revolut text! |
-| invoice without amount | Revolut (iOS)          |          | message replaced with revolut text! |
-| donation               | UBS (iOS)              |          |                                     |
-| invoice                | UBS (iOS)              |          |                                     |
-| invoice without amount | UBS (iOS)              |          |                                     |
-| donation               | Postfinance (Android)  |          |                                     |
-| invoice                | Postfinance (Android)  |          |                                     |
-| invoice without amount | Postfinance (Android)  |          |                                     |
-| donation               | Raiffeisen (Android)   |          |                                     |
-| invoice                | Raiffeisen (Android)   |          |                                     |
-| invoice without amount | Raiffeisen (Android)   |          |                                     |
-| donation               | UBS (Android)          |          |                                     |
-| invoice                | UBS (Android)          |          |                                     |
-| invoice without amount | UBS (Android)          |          |                                     |
-| donation               | Credit Suisse (iOS)    |          |                                     |
-| invoice                | Credit Suisse (iOS)    |          |                                     |
-| invoice without amount | Credit Suisse (iOS)    |          |                                     |
-| donation               | ZKB eBanking (Android) |          |                                     |
-| invoice                | ZKB eBanking (Android) |          |                                     |
-| invoice without amount | ZKB eBanking (Android) |          |                                     |
+| QR code                | scanned with              | paid via | Notes                                      |
+|------------------------|---------------------------|----------|--------------------------------------------|
+| donation               | SIX QR-bill validation    |          |                                            |
+| invoice                | SIX QR-bill validation    |          |                                            |
+| invoice without amount | SIX QR-bill validation    |          |                                            |
+| donation               | ZKB eBanking (iOS)        | ZKB      |                                            |
+| invoice                | ZKB eBanking (iOS)        |          |                                            |
+| invoice without amount | ZKB eBanking (iOS)        |          |                                            |
+| donation               | Revolut (iOS)             |          |                                            |
+| invoice                | Revolut (iOS)             |          | message replaced with revolut text!        |
+| invoice without amount | Revolut (iOS)             |          | message replaced with revolut text!        |
+| donation               | UBS (iOS)                 |          |                                            |
+| invoice                | UBS (iOS)                 |          |                                            |
+| invoice without amount | UBS (iOS)                 |          |                                            |
+| donation               | Postfinance (Android)     |          |                                            |
+| invoice                | Postfinance (Android)     |          |                                            |
+| invoice without amount | Postfinance (Android)     |          |                                            |
+| donation               | Raiffeisen (Android)      |          |                                            |
+| invoice                | Raiffeisen (Android)      |          |                                            |
+| invoice without amount | Raiffeisen (Android)      |          |                                            |
+| donation               | UBS (Android)             |          |                                            |
+| invoice                | UBS (Android)             |          |                                            |
+| invoice without amount | UBS (Android)             |          |                                            |
+| donation               | Credit Suisse (iOS)       |          |                                            |
+| invoice                | Credit Suisse (iOS)       |          |                                            |
+| invoice without amount | Credit Suisse (iOS)       |          |                                            |
+| donation               | ZKB eBanking (Android)    |          |                                            |
+| invoice                | ZKB eBanking (Android)    |          |                                            |
+| invoice without amount | ZKB eBanking (Android)    |          |                                            |
+| donation               | Zak - Bank Cler (Android) |          |                                            |
+| invoice                | Zak - Bank Cler (Android) |          | no mention of "Mary Jane" or "Artikel 19b" |
+| invoice without amount | Zak - Bank Cler (Android) |          | no mention of "Mary Jane" or "Artikel 19b" |
 
 ### qrbill v0.1.3 (2020-Sep-10)
 


### PR DESCRIPTION
Tested Zak, but same problem as in https://github.com/stapelberg/qrbill/pull/1. I'm not surprised either, because the Zak app is complete rubbish anyway.

![20200929_082714100_iOS](https://user-images.githubusercontent.com/4533780/94535754-367a1680-0242-11eb-92cb-e0dcaeb7c0e2.jpg)

Then I wanted to test [neon](https://www.neon-free.ch/). But there the scan function is broken. The picture is distorted, the QR code is not recognized at all. Tested with: Pixel 3a, Android 11. without modification, without root. Original Software. Maybe Neon is not yet compatible with Android 11, who knows.

![Screenshot_20200929-104257](https://user-images.githubusercontent.com/4533780/94536135-b1dbc800-0242-11eb-89cd-b37d44a2ecfa.png)
