### PR TITLE
Validate Ultimate Debtor

### DIFF
--- a/qrbill.go
+++ b/qrbill.go
@@ -192,6 +192,8 @@ func (q *QRCH) Validate() *QRCH {
 
 	clone.UltmtCdtr = clone.UltmtCdtr.Validate()
 
+	clone.UltmtDbtr = clone.UltmtDbtr.Validate()
+
 	clone.RmtInf.Tp = nonAlphanumericRe.ReplaceAllString(clone.RmtInf.Tp, "")
 	if v := clone.RmtInf.Tp; len(v) > 4 {
 		clone.RmtInf.Tp = v[:4]


### PR DESCRIPTION
At least some swiss banking apps don't accept
ultimate deptor values longer than permitted.